### PR TITLE
feat(raspi): add custom and more central exception handling

### DIFF
--- a/raspi/raspi_loggr/exception_handler.py
+++ b/raspi/raspi_loggr/exception_handler.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import logging
+
+
+class SensorScriptException(Exception):
+    def __init__(self, cpe):
+        self.rc = str(cpe.returncode)
+        self.output = str(cpe.output)
+        self.cmd = str(cpe.cmd[0])
+
+    def logErrors(self):
+        # 1 = catch wiringPi errors
+        # 2 = catch open device file errors of mounted devices
+        # 3 = catch read errors on devices
+        logging.error('called process error: ' + self.cmd + ' returned ' + self.rc + ': ' + self.output)
+        print 'called process error: ' + self.cmd + ' returned ' + self.rc + ': ' + self.output
+
+
+class LedException(Exception):
+    def __init__(self, le):
+        self.rc = le.returncode
+        self.cmd = str(le.cmd[0])
+
+    def logErrors(self):
+        if self.rc == 1:
+            # catch wiringPi errors
+            logging.error('called process error: ' + self.cmd + ' returned 1: setup wiringPi failed')
+            print 'called process error: ' + self.cmd + ' returned 1: setup wiringPi failed'
+        elif self.rc == 4:
+            # catch invalid arguments errors
+            logging.error('called process error: ' + self.cmd + ' returned 1: invalid arguments')
+            print 'called process error: ' + self.cmd + ' returned 1: invalid arguments'

--- a/raspi/raspi_loggr/sensor.py
+++ b/raspi/raspi_loggr/sensor.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from .util import set_status_led
 from .util import LedStatusTypes
 from .util import SensorTypes
+from .exception_handler import SensorScriptException
 
 # TODO: CONFIG FILE
 DB = 'meterings'
@@ -73,23 +74,11 @@ class Sensor:
             command = PATH + self.sensor_type + SUFFIX
             try:
                 subproc_output = subprocess.check_output(command, stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError, cpe:
-                if cpe.returncode == 1:
-                    # catch wiringPi errors
-                    logging.error('called process error: ' + str(cpe.cmd[0]) + ' returned 1: ' + cpe.output)
-                    print 'called process error: ' + str(cpe.cmd[0]) + ' returned 1: ' + cpe.output
-                elif cpe.returncode == 2:
-                    # catch open device file errors of mounted devices
-                    logging.error('called process error: ' + str(cpe.cmd[0]) + ' returned 2: ' + cpe.output)
-                    print 'called process error: ' + str(cpe.cmd[0]) + ' returned 2: ' + cpe.output
-                elif cpe.returncode == 3:
-                    # catch read errors on devices
-                    logging.error('called process error: ' + str(cpe.cmd[0]) + ' returned 3: ' + cpe.output)
-                    print 'called process error: ' + str(cpe.cmd[0]) + ' returned 3: ' + cpe.output
-            except OSError, ose:
+            except subprocess.CalledProcessError as cpe:
+                raise SensorScriptException(cpe)
+            except OSError as ose:
                 # catch os errors, e.g. file-not-found
-                logging.error('oserror: ' + str(ose.strerror))
-                print 'oserror: ' + str(ose.strerror)
+                raise
             else:
                 logging.info('metering of ' + self.sensor_type + ' sensor: ' + str(subproc_output))
                 print 'metering of ' + self.sensor_type + ' sensor: ' + str(subproc_output)
@@ -99,10 +88,10 @@ class Sensor:
         headers = {'Content-Type': 'application/json'}
         try:
             r = requests.post(API + "/" + DB, data=json.dumps(payload), headers=headers)
-        except requests.exceptions.RequestException, e:
+        except requests.exceptions.RequestException as re:
             # catch requests errors
-            logging.error('requests failure: ' + str(e))
-            print 'requests failure: ' + str(e)
+            logging.error('requests failure: ' + str(re))
+            print 'requests failure: ' + str(re)
             set_status_led(LedStatusTypes.request_error.name)
         else:
             logging.info('requests status code: ' + str(r.status_code))

--- a/raspi/raspi_loggr/util.py
+++ b/raspi/raspi_loggr/util.py
@@ -3,6 +3,7 @@
 import subprocess
 import logging
 from enum import Enum
+from .exception_handler import LedException
 
 
 class LedStatusTypes(Enum):
@@ -31,19 +32,6 @@ class ValueUnits(Enum):
 def set_status_led(status):
     command = ['sensors/rgb.out', str(status)]
     try:
-        subproc = subprocess.check_call(command,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError, cpe:
-        if cpe.returncode == 1:
-            # catch invalid arguments errors
-            logging.error('called process error: ' + str(cpe.cmd[0]) + ' returned 1: invalid arguments')
-            print 'called process error: ' + str(cpe.cmd[0]) + ' returned 1: invalid arguments'
-        elif cpe.returncode == 2:
-            # catch wiringPi errors
-            logging.error('called process error: ' + str(cpe.cmd[0]) + ' returned 2: setup wiringPi failed')
-            print 'called process error: ' + str(cpe.cmd[0]) + ' returned 2: setup wiringPi failed'
-    except OSError, ose:
-        # catch os errors, e.g. file-not-found
-        logging.error('oserror: ' + str(ose.strerror))
-        print 'oserror: ' + str(ose.strerror)
+        subproc = subprocess.check_call(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as le:
+        raise LedException(le)

--- a/raspi/sensors/rgb.c
+++ b/raspi/sensors/rgb.c
@@ -50,12 +50,12 @@ int main(int argc, const char *argv[])
 {
   if (argc != 2) {
     printf("invalid arguments! Usage: ./rgb.out <error-code>\n");
-    return 1;
+    return 4;
   }
 
   if(wiringPiSetup() == -1) {
     printf("setup wiringPi failed!");
-    return 2;
+    return 1;
   }
 
   ledInit();


### PR DESCRIPTION
So, habe jetzt mal versucht, das Error Handling zentraler zu gestalten und Exception so raisen, welche wirklich speziell auf den Error zugeschnitten sind.

Das ist an sich ganz schön, allerdings gibts dann Umstände, die wir überhaupt nicht haben wollen...

Und zwar ist es jetzt so, wenn beim Messen, Versenden oder der Anzeige der LED bei einem einzelnen Sensor eine Exception kommt, wird die komplette Messung auch für die anderen Sensoren abgebrochen. Das ist natürlich nicht wirklich gewünscht.

Ich denke wir sollten wieder die Exception lokal fangen, das macht weniger Probleme und funktioniert dann auch so, wie wir es wollen. Also genauso, wie es aktuell im master-Branch ist.
